### PR TITLE
fix pftaskqueue worker can log colorized handler output properly

### DIFF
--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -553,7 +553,7 @@ func (w *Worker) startStreamToLogger(cmdCtx context.Context, wg *sync.WaitGroup,
 				if allLinesProcessed {
 					return
 				}
-				logger.Info().Msg(strconv.Quote(strings.TrimRight(line, "\n")))
+				logger.Info().Msg(strings.TrimRight(line, "\n"))
 			}
 		}
 	}()


### PR DESCRIPTION
fixes #15 
![image](https://user-images.githubusercontent.com/608782/85505847-31497200-b62a-11ea-8f40-53524eb18bf5.png)
