### PR TITLE
Set config file path via PFTQCONFIG env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,9 +710,11 @@ $ pftaskqueue print-default-config > ~/.pftaskqueue.yaml
 $ PFTQ_REDIS_ADDR=... pftaskqueue ...
 ```
 
-### Config files
+### Config file
 
-`pftaskqueue` automatically reads `${HOME}/.pftaskqueue.yaml` if exists.  Or, you can also set any configuration path with `--config=${CONFIG_FILE_PATH}` flag or both.
+`pftaskqueue` automatically reads `${HOME}/.pftaskqueue.yaml` if exists.
+Or, you can also set any configuration path with `--config=${CONFIG_FILE_PATH}` flag or `PFTQ_CONFIG` environment variable.
+`--config` flag is prioritized over `PFTQ_CONFIG` environment variable.
 
 To generate config file with default values, please run `print-default-config` command.
 

--- a/README.md
+++ b/README.md
@@ -713,8 +713,8 @@ $ PFTQ_REDIS_ADDR=... pftaskqueue ...
 ### Config file
 
 `pftaskqueue` automatically reads `${HOME}/.pftaskqueue.yaml` if exists.
-Or, you can also set any configuration path with `--config=${CONFIG_FILE_PATH}` flag or `PFTQ_CONFIG` environment variable.
-`--config` flag is prioritized over `PFTQ_CONFIG` environment variable.
+Or, you can also set any configuration path with `--config=${CONFIG_FILE_PATH}` flag or `PFTQCONFIG` environment variable.
+`--config` flag is prioritized over `PFTQCONFIG` environment variable.
 
 To generate config file with default values, please run `print-default-config` command.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -144,7 +144,7 @@ func init() {
 
 	rootCmd.SetVersionTemplate(VersionString())
 	flag := rootCmd.PersistentFlags()
-	flag.StringVar(&cfgFile, "config", "", "config file path. [default = $PFTQ_CONFIG or $HOME/.pftaskqueue.yaml]")
+	flag.StringVar(&cfgFile, "config", "", "config file path. [default = $PFTQCONFIG or $HOME/.pftaskqueue.yaml]")
 	flag.BoolVar(&displayOpts, "display-options", false, "display loaded config values at startup")
 
 	// Log setting
@@ -239,7 +239,7 @@ func initConfig() {
 	if cfgFile != "" {
 		// Use config file from the flag.
 		viper.SetConfigFile(cfgFile)
-	} else if env, ok := os.LookupEnv("PFTQ_CONFIG"); ok {
+	} else if env, ok := os.LookupEnv("PFTQCONFIG"); ok {
 		// Use config file from env var.
 		viper.SetConfigFile(env)
 	} else {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -144,7 +144,7 @@ func init() {
 
 	rootCmd.SetVersionTemplate(VersionString())
 	flag := rootCmd.PersistentFlags()
-	flag.StringVar(&cfgFile, "config", "", "config file path. [default = $HOME/.pftaskqueue.yaml]")
+	flag.StringVar(&cfgFile, "config", "", "config file path. [default = $PFTQ_CONFIG or $HOME/.pftaskqueue.yaml]")
 	flag.BoolVar(&displayOpts, "display-options", false, "display loaded config values at startup")
 
 	// Log setting
@@ -239,6 +239,9 @@ func initConfig() {
 	if cfgFile != "" {
 		// Use config file from the flag.
 		viper.SetConfigFile(cfgFile)
+	} else if env, ok := os.LookupEnv("PFTQ_CONFIG"); ok {
+		// Use config file from env var.
+		viper.SetConfigFile(env)
 	} else {
 		// Find home directory.
 		home, err := homedir.Dir()


### PR DESCRIPTION
With this PR merged, pftaskqueue will read `PFTQ_CONFIG` environment variable (if set) to get the path of a config file.
`--config` flag is prioritized over `PFTQ_CONFIG` env var, so this change should not break the current behavior.

This feature would be useful when one does not want to place `.pftaskqueue.yaml` on a home directory and does not also want to type `--config=...` flag every time.