### PR TITLE
fix 'worker.taskHandler.defaultTimeout' and `--default-command-timeout` are ignored

### DIFF
--- a/cmd/start_worker.go
+++ b/cmd/start_worker.go
@@ -94,7 +94,7 @@ func init() {
 	viperBindPFlag("Worker.Concurrency", strconv.Itoa(cmdOpts.Worker.Concurrency), flag.Lookup("concurrency"))
 
 	flag.Duration("default-command-timeout", cmdOpts.Worker.TaskHandler.DefaultCommandTimeout, "default timeout for executing command for tasks. the value will be used when the taskspec has no timeout spec")
-	viperBindPFlag("Worker.TaskHandler.DefaultCommandTimeout", cmdOpts.Worker.TaskHandler.DefaultCommandTimeout.String(), flag.Lookup("default-command-timeout"))
+	viperBindPFlag("Worker.TaskHandler.DefaultTimeout", cmdOpts.Worker.TaskHandler.DefaultCommandTimeout.String(), flag.Lookup("default-command-timeout"))
 
 	flag.Bool("exit-on-suspend", cmdOpts.Worker.ExitOnSuspend, "if set, worker exits when queue is suspended")
 	viperBindPFlag("Worker.ExitOnSuspend", strconv.FormatBool(cmdOpts.Worker.ExitOnSuspend), flag.Lookup("exit-on-suspend"))

--- a/pkg/apis/worker/worker.go
+++ b/pkg/apis/worker/worker.go
@@ -74,7 +74,7 @@ type WorkerSpec struct {
 }
 
 type TaskHandlerSpec struct {
-	DefaultCommandTimeout time.Duration `json:"defaultTimeout" yaml:"defaultTimeout" default:"30m" validate:"required"`
+	DefaultCommandTimeout time.Duration `json:"defaultTimeout" yaml:"defaultTimeout" mapstructure:"defaultTimeout" default:"30m" validate:"required"`
 	Commands              []string      `json:"commands" yaml:"commands" default:"[\"cat\"]" validate:"required"`
 }
 


### PR DESCRIPTION
fixes #30 

```shell
$ ./dist/pftaskqueue version
{"Version": "v0.3.6-alpha.0", "Revision": "2be0cd8"}

$ ./dist/pftaskqueue print-default-config | sed 's/defaultTimeout: 30m0s/defaultTimeout: 60m0s/' | tee  config.yaml
backend: redis
redis:
  keyPrefix: ""
  addr: ""
  password: ""
  db: 0
  dialTimeout: 30s
  readTimeout: 10m0s
  writeTimeout: 10m0s
  poolSize: 0
  minIdleConns: 0
  maxConnAge: 0s
  poolTimeout: 0s
  idleTimeout: 5m0s
  idleCheckFrequency: 1m0s
  chunkSizeInGet: 10000
  backoff:
    initialInterval: 500ms
    randomizationFactor: 0.5
    multiplier: 1.2
    maxInterval: 1m0s
    maxElapsedTime: 10m0s
    maxRetry: -1
worker:
  queueName: ""
  name: ""
  concurrency: 1
  taskHandler:
    defaultTimeout: 60m0s
    commands:
    - cat
  heartBeat:
    salvageDuration: 15s
    expirationDuration: 10s
    interval: 2s
  exitOnSuspend: true
  exitOnEmpty: false
  exitOnEmptyGracePeriod: 10s
  numTasks: 100
  workDir: /tmp
  numWorkerSalvageOnStartup: -1
log:
  level: info
  pretty: true

$ ./dist/pftaskqueue --config config.yaml print-config
backend: redis
redis:
  keyPrefix: ""
  addr: ""
  password: ""
  db: 0
  dialTimeout: 30s
  readTimeout: 10m0s
  writeTimeout: 10m0s
  poolSize: 0
  minIdleConns: 0
  maxConnAge: 0s
  poolTimeout: 0s
  idleTimeout: 5m0s
  idleCheckFrequency: 1m0s
  chunkSizeInGet: 10000
  backoff:
    initialInterval: 500ms
    randomizationFactor: 0.5
    multiplier: 1.2
    maxInterval: 1m0s
    maxElapsedTime: 10m0s
    maxRetry: -1
worker:
  queueName: ""
  name: ""
  concurrency: 1
  taskHandler:
    defaultTimeout: 1h0m0s
    commands:
    - cat
  heartBeat:
    salvageDuration: 15s
    expirationDuration: 10s
    interval: 2s
  exitOnSuspend: true
  exitOnEmpty: false
  exitOnEmptyGracePeriod: 10s
  numTasks: 100
  workDir: /tmp
  numWorkerSalvageOnStartup: -1
log:
  level: info
  pretty: true
```