### PR TITLE
Worker should kill task handler process and its descendant processes cleanly when timeout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.13
+        go-version: ^1.14
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.13
+          go-version: ^1.14
         id: go
       - name: Check out
         uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.13
+          go-version: ^1.14
         id: go
       - name: Check out
         uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.13
+          go-version: ^1.14
         id: go
       - name: Check out
         uses: actions/checkout@v2

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,7 +9,6 @@ builds:
   binary: pftaskqueue
   goos:
   - linux
-  - windows
   - darwin
   goarch:
   - amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.5 as builder
+FROM golang:1.14 as builder
 ARG RELEASE
 ARG VERSION
 WORKDIR /workspace

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pfnet-research/pftaskqueue
 
-go 1.13
+go 1.14
 
 require (
 	github.com/MakeNowJust/heredoc/v2 v2.0.1


### PR DESCRIPTION
- fixes #32 
- __BREAKING CHANGE: This drops windows binary support because this feature requires `setpgid`__
  - I think it doesn't affect much because windows users can WSL2.

```shell
$ cat test.sh
#! /bin/bash
sleep 1000

$ ./dist/pftaskqueue start-worker --default-command-timeout 10s --queue-name=test --name=test -- bash ./test.sh
9:18PM INF Start processing a task component=worker processUID=e1543f1f-4bed-463f-a4a7-23c24d2223f0 queueName=test queueUID=9d782669-acb2-4846-89ee-1ae859395c08 taskHandlerCommands=["bash","./test.sh"] taskSpec={"name":"task1","payload":"payload"} taskUID=90eb3dc8-9461-4194-ad9a-ad0f3970ff73 workerName=test workerUID=6e1dca1e-00bc-414f-90ee-71e4bcdf5fbd
9:18PM ERR Task handler process timeout error="context deadline exceeded" component=worker postHooks=[] processUID=e1543f1f-4bed-463f-a4a7-23c24d2223f0 queueName=test queueUID=9d782669-acb2-4846-89ee-1ae859395c08 taskHandlerCommands=["bash","./test.sh"] taskResult={"reason":"Timeout","type":"Failure"} taskSpec={"name":"task1","payload":"payload"} taskUID=90eb3dc8-9461-4194-ad9a-ad0f3970ff73 workerName=test workerUID=6e1dca1e-00bc-414f-90ee-71e4bcdf5fbd
9:18PM INF Completed As Failure because retry exhausted component=redis-backend failureCount=1 operation=RecordFailure queueName=test queueUID=9d782669-acb2-4846-89ee-1ae859395c08 retryLimit=0 workerName=test workerUID=6e1dca1e-00bc-414f-90ee-71e4bcdf5fbd
9:18PM INF Task marked Failure component=worker processUID=e1543f1f-4bed-463f-a4a7-23c24d2223f0 queueName=test queueUID=9d782669-acb2-4846-89ee-1ae859395c08 taskResult={"reason":"Timeout","type":"Failure"} taskSpec={"name":"task1","payload":"payload"} taskUID=90eb3dc8-9461-4194-ad9a-ad0f3970ff73 workerName=test workerUID=6e1dca1e-00bc-414f-90ee-71e4bcdf5fbd
9:18PM INF Queue is empty. retrying in 5 seconds. component=worker detectedQueueEmptyAt=2020-09-29T21:18:47+09:00 exitOnEmpty=false exitOnEmptyGracePeriod=10000 queueName=test queueUID=9d782669-acb2-4846-89ee-1ae859395c08 workerName=test workerUID=6e1dca1e-00bc-414f-90ee-71e4bcdf5fbd
...

# in another shell
# no subprocesses remains!!
$ ps -efj | egrep "[s]leep 1000"

```