### PR TITLE
Fix --num-tasks description

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ worker:
   exitOnEmpty: false
   # If exitOnEmpty is true, worker waits for exit in the grace period
   exitOnEmptyGracePeriod: 10s
-  # If the value was positive, worker will exit 
+  # If the value was non-negative, worker will exit
   # after processing the number of tasks
   numTasks: 1000
   # Base directory to create workspace for task handler processes

--- a/cmd/start_worker.go
+++ b/cmd/start_worker.go
@@ -105,7 +105,7 @@ func init() {
 	flag.Duration("exit-on-empty-grace-period", cmdOpts.Worker.ExitOnEmptyGracePeriod, "if exit-on-empty is true, worker waits for exit in the grace period")
 	viperBindPFlag("Worker.ExitOnEmptyGracePeriod", cmdOpts.Worker.ExitOnEmptyGracePeriod.String(), flag.Lookup("exit-on-empty-grace-period"))
 
-	flag.Int("num-tasks", cmdOpts.Worker.NumTasks, "if set positive value, worker exits after processing the number of tasks")
+	flag.Int("num-tasks", cmdOpts.Worker.NumTasks, "if set non-negative value, worker exits after processing the number of tasks")
 	viperBindPFlag("Worker.NumTasks", strconv.Itoa(cmdOpts.Worker.NumTasks), flag.Lookup("num-tasks"))
 
 	flag.String("work-dir", cmdOpts.Worker.WorkDir, "worker's working directory.  the dir must be writable")


### PR DESCRIPTION
The description of `--num-tasks` seems to be wrong, and this PR fixes the description.

`--num-tasks` description says that "if the value is 0, worker will process infinite number of tasks".
But when I set `--num-tasks` to 0, the worker exits soon after initialization.

related code:
https://github.com/pfnet-research/pftaskqueue/blob/55995688156021c3d7bb51ba4e225b15ed0501b3/pkg/worker/worker.go#L128