### PR TITLE
Implement bulk key fetching and deleting for large queue without transaction

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -297,10 +297,11 @@ func mustInitializeQueueBackend() {
 		queueBackend, err = backendfactory.NewBackend(logger, backendconfig.Config{
 			BackendType: cmdOpts.Backend,
 			Redis: &backendconfig.RedisConfig{
-				KeyPrefix:      cmdOpts.Redis.KeyPrefix,
-				Client:         cmdOpts.Redis.NewClient(),
-				Backoff:        cmdOpts.Redis.Backoff,
-				ChunkSizeInGet: cmdOpts.Redis.ChunkSizeInGet,
+				KeyPrefix:         cmdOpts.Redis.KeyPrefix,
+				Client:            cmdOpts.Redis.NewClient(),
+				Backoff:           cmdOpts.Redis.Backoff,
+				ChunkSizeInGet:    cmdOpts.Redis.ChunkSizeInGet,
+				ChunkSizeInDelete: cmdOpts.Redis.ChunkSizeInDelete,
 			},
 		})
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -297,11 +297,12 @@ func mustInitializeQueueBackend() {
 		queueBackend, err = backendfactory.NewBackend(logger, backendconfig.Config{
 			BackendType: cmdOpts.Backend,
 			Redis: &backendconfig.RedisConfig{
-				KeyPrefix:         cmdOpts.Redis.KeyPrefix,
-				Client:            cmdOpts.Redis.NewClient(),
-				Backoff:           cmdOpts.Redis.Backoff,
-				ChunkSizeInGet:    cmdOpts.Redis.ChunkSizeInGet,
-				ChunkSizeInDelete: cmdOpts.Redis.ChunkSizeInDelete,
+				KeyPrefix:          cmdOpts.Redis.KeyPrefix,
+				Client:             cmdOpts.Redis.NewClient(),
+				Backoff:            cmdOpts.Redis.Backoff,
+				ChunkSizeInGet:     cmdOpts.Redis.ChunkSizeInGet,
+				ChunkSizeInDelete:  cmdOpts.Redis.ChunkSizeInDelete,
+				WithoutTransaction: cmdOpts.Redis.WithoutTransaction,
 			},
 		})
 

--- a/pkg/backend/config/config.go
+++ b/pkg/backend/config/config.go
@@ -54,7 +54,7 @@ type RedisClientConfig struct {
 	IdleCheckFrequency time.Duration `json:"idleCheckFrequency" yaml:"idleCheckFrequency" default:"1m"`
 
 	ChunkSizeInGet    int `json:"chunkSizeInGet" yaml:"chunkSizeInGet" default:"10000"`
-	ChunkSizeInDelete int `json:"chunkSizeInDelete" yaml:"chunkSizeInGet" default:"1000"`
+	ChunkSizeInDelete int `json:"chunkSizeInDelete" yaml:"chunkSizeInDelete" default:"1000"`
 }
 
 func (c RedisClientConfig) NewClient() *redis.Client {

--- a/pkg/backend/config/config.go
+++ b/pkg/backend/config/config.go
@@ -30,10 +30,11 @@ type Config struct {
 }
 
 type RedisConfig struct {
-	KeyPrefix      string
-	Client         *redis.Client
-	Backoff        BackoffConfig
-	ChunkSizeInGet int
+	KeyPrefix         string
+	Client            *redis.Client
+	Backoff           BackoffConfig
+	ChunkSizeInGet    int
+	ChunkSizeInDelete int
 }
 
 // TODO: support UniversalOptions
@@ -52,7 +53,8 @@ type RedisClientConfig struct {
 	IdleTimeout        time.Duration `json:"idleTimeout" yaml:"idleTimeout" default:"5m"`
 	IdleCheckFrequency time.Duration `json:"idleCheckFrequency" yaml:"idleCheckFrequency" default:"1m"`
 
-	ChunkSizeInGet int `json:"chunkSizeInGet" yaml:"chunkSizeInGet" default:"10000"`
+	ChunkSizeInGet    int `json:"chunkSizeInGet" yaml:"chunkSizeInGet" default:"10000"`
+	ChunkSizeInDelete int `json:"chunkSizeInDelete" yaml:"chunkSizeInGet" default:"1000"`
 }
 
 func (c RedisClientConfig) NewClient() *redis.Client {

--- a/pkg/backend/config/config.go
+++ b/pkg/backend/config/config.go
@@ -30,11 +30,12 @@ type Config struct {
 }
 
 type RedisConfig struct {
-	KeyPrefix         string
-	Client            *redis.Client
-	Backoff           BackoffConfig
-	ChunkSizeInGet    int
-	ChunkSizeInDelete int
+	KeyPrefix          string
+	Client             *redis.Client
+	Backoff            BackoffConfig
+	ChunkSizeInGet     int
+	ChunkSizeInDelete  int
+	WithoutTransaction bool
 }
 
 // TODO: support UniversalOptions
@@ -53,8 +54,9 @@ type RedisClientConfig struct {
 	IdleTimeout        time.Duration `json:"idleTimeout" yaml:"idleTimeout" default:"5m"`
 	IdleCheckFrequency time.Duration `json:"idleCheckFrequency" yaml:"idleCheckFrequency" default:"1m"`
 
-	ChunkSizeInGet    int `json:"chunkSizeInGet" yaml:"chunkSizeInGet" default:"10000"`
-	ChunkSizeInDelete int `json:"chunkSizeInDelete" yaml:"chunkSizeInDelete" default:"1000"`
+	ChunkSizeInGet     int  `json:"chunkSizeInGet" yaml:"chunkSizeInGet" default:"10000"`
+	ChunkSizeInDelete  int  `json:"chunkSizeInDelete" yaml:"chunkSizeInDelete" default:"1000"`
+	WithoutTransaction bool `json:"withoutTransaction" yaml:"withoutTransaction" default:"false"`
 }
 
 func (c RedisClientConfig) NewClient() *redis.Client {

--- a/pkg/backend/iface/backend.go
+++ b/pkg/backend/iface/backend.go
@@ -32,6 +32,7 @@ var (
 	TaskQueueNotFound         = errors.New("Queue not found")
 	TaskQueueExisted          = errors.New("Queue already exists")
 	TaskQueueEmptyError       = errors.New("Queue is empty")
+	TaskQueueIsTooLarge       = errors.New("Queue have many tasks so we need --without_transaction option")
 	TaskSuspendedError        = errors.New("Queue is suspended")
 	WorkerNotFound            = errors.New("Worker not found")
 	WorkerExitedError         = errors.New("Worker already exists")

--- a/pkg/backend/redis/queue.go
+++ b/pkg/backend/redis/queue.go
@@ -218,7 +218,7 @@ func (b *Backend) DeleteQueue(ctx context.Context, queueName string) error {
 	// .. task_keys = collect task keys
 	// WATCh task_keys
 	// MULTI
-	// UNLINK {queue_key} worker_keys task_keys
+	// UNLINK {queue_key} worker_keys task_keys (chunked)
 	// HDEL {all_queues_key} {queueName}
 	// EXEC
 	txf := func(tx *redis.Tx) error {
@@ -240,7 +240,7 @@ func (b *Backend) DeleteQueue(ctx context.Context, queueName string) error {
 		tx.Watch(taskKeysToDelete...)
 		keysToDelete = append(keysToDelete, taskKeysToDelete...)
 
-		chunkSize := b.ChunkSizeInGet
+		chunkSize := b.ChunkSizeInDelete
 		numOfKeysToDelete := len(keysToDelete)
 		_, err = tx.TxPipelined(func(pipe redis.Pipeliner) error {
 			for begin := 0; begin < numOfKeysToDelete; begin += chunkSize {

--- a/pkg/backend/redis/queue.go
+++ b/pkg/backend/redis/queue.go
@@ -204,7 +204,7 @@ func (b *Backend) UpdateQueue(ctx context.Context, queueSpec taskqueue.TaskQueue
 	return queue, nil
 }
 
-func (b *Backend) DeleteQueue(ctx context.Context, queueName string) error {
+func (b *Backend) deleteQueueWithTransaction(ctx context.Context, queueName string) error {
 	if err := taskqueue.ValidateQueueName(queueName); err != nil {
 		return err
 	}
@@ -212,13 +212,23 @@ func (b *Backend) DeleteQueue(ctx context.Context, queueName string) error {
 	if err != nil {
 		return err
 	}
+
+	numOfTasks, err := b.Client.SCard(b.tasksKey(queue.UID.String())).Result()
+	if err != nil {
+		return err
+	}
+
+	if int64(b.ChunkSizeInDelete) <= numOfTasks {
+		return iface.TaskQueueIsTooLarge
+	}
+
 	// WATCH {all_queues_key} {queue_key}
 	// .. worker_keys = collect worker keys
 	// WATCH worker_keys
 	// .. task_keys = collect task keys
 	// WATCh task_keys
 	// MULTI
-	// UNLINK {queue_key} worker_keys task_keys (chunked)
+	// DEL {queue_key} worker_keys task_keys
 	// HDEL {all_queues_key} {queueName}
 	// EXEC
 	txf := func(tx *redis.Tx) error {
@@ -240,16 +250,8 @@ func (b *Backend) DeleteQueue(ctx context.Context, queueName string) error {
 		tx.Watch(taskKeysToDelete...)
 		keysToDelete = append(keysToDelete, taskKeysToDelete...)
 
-		chunkSize := b.ChunkSizeInDelete
-		numOfKeysToDelete := len(keysToDelete)
 		_, err = tx.TxPipelined(func(pipe redis.Pipeliner) error {
-			for begin := 0; begin < numOfKeysToDelete; begin += chunkSize {
-				end := begin + chunkSize
-				if end > numOfKeysToDelete {
-					end = numOfKeysToDelete
-				}
-				pipe.Unlink(keysToDelete[begin:end]...)
-			}
+			pipe.Del(keysToDelete...)
 			pipe.HDel(b.allQueuesKey(), queue.Spec.Name)
 			return nil
 		})
@@ -260,11 +262,106 @@ func (b *Backend) DeleteQueue(ctx context.Context, queueName string) error {
 		b.Logger.With().
 			Str("queueName", queueName).
 			Str("queueUID", queue.UID.String()).
-			Str("operation", "DeleteQueue").
+			Str("operation", "DeleteQueueWithTransaction").
 			Logger(),
 		txf,
 		b.allQueuesKey(), b.queueKey(queue.UID.String()),
 	)
+}
+
+func (b *Backend) deleteQueueWithoutTransaction(ctx context.Context, queueName string) error {
+	if err := taskqueue.ValidateQueueName(queueName); err != nil {
+		return err
+	}
+	queue, err := b.ensureQueueExistsByName(b.Client, queueName)
+	if err != nil {
+		return err
+	}
+	//
+	// .. worker_keys = collect worker keys
+	// .. task_keys = collect task keys
+	// Use chunk to divide and loop until UNLINK all keys
+	// ---loop start---
+	// WATCH {all_queues_key} {queue_key}
+	// UNLINK chulk_keys
+	// ---loop end---
+	// WATCH {all_queues_key} {queue_key}
+	// MULTI
+	// DEL {queue_key} worker_keys task_keys
+	// HDEL {all_queues_key} {queueName}
+	// EXEC
+	keysToDelete := []string{}
+
+	workerKeysToDelete, err := b.allWorkersKeysForDeleteQueue(b.Client, queue.UID.String())
+	if err != nil {
+		return err
+	}
+	keysToDelete = append(keysToDelete, workerKeysToDelete...)
+
+	taskKeysToDelete, err := b.allTasksKeysForDeleteQueue(b.Client, queue.UID.String())
+	if err != nil {
+		return err
+	}
+	keysToDelete = append(keysToDelete, taskKeysToDelete...)
+
+	// chunk delete
+	for cursor := 0; cursor < len(keysToDelete); cursor += b.ChunkSizeInDelete {
+		time.Sleep(100 * time.Millisecond)
+		end := cursor + b.ChunkSizeInDelete
+		if len(keysToDelete) <= end {
+			end = len(keysToDelete)
+		}
+
+		deleteKeys := keysToDelete[cursor:end]
+		if len(deleteKeys) == 0 {
+			continue
+		}
+		err = b.runTxWithBackOff(
+			ctx,
+			b.Logger.With().
+				Str("queueName", queueName).
+				Str("queueUID", queue.UID.String()).
+				Str("operation", "DeleteQueueWithTransaction").
+				Logger(),
+			func(tx *redis.Tx) error {
+				_, err = tx.Unlink(deleteKeys...).Result()
+				return err
+			},
+			b.allQueuesKey(), b.queueKey(queue.UID.String()),
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = b.runTxWithBackOff(
+		ctx,
+		b.Logger.With().
+			Str("queueName", queueName).
+			Str("queueUID", queue.UID.String()).
+			Str("operation", "DeleteQueueWithTransaction").
+			Logger(),
+		func(tx *redis.Tx) error {
+			_, err = tx.Unlink(b.queueKey(queue.UID.String())).Result()
+			if err != nil {
+				return err
+			}
+
+			_, err = tx.HDel(b.allQueuesKey(), queue.Spec.Name).Result()
+			return err
+		},
+		b.allQueuesKey(), b.queueKey(queue.UID.String()),
+	)
+
+	return err
+}
+
+func (b *Backend) DeleteQueue(ctx context.Context, queueName string) error {
+	if b.WithoutTransaction {
+		return b.deleteQueueWithoutTransaction(ctx, queueName)
+	} else {
+		return b.deleteQueueWithTransaction(ctx, queueName)
+	}
 }
 
 func (b *Backend) ensureQueueExistsByName(rds redis.Cmdable, queueName string) (*taskqueue.TaskQueue, error) {

--- a/pkg/backend/redis/redis_test.go
+++ b/pkg/backend/redis/redis_test.go
@@ -107,10 +107,11 @@ var _ = Describe("Backend", func() {
 		ibackend, err := NewBackend(logger, backendconfig.Config{
 			BackendType: "redis",
 			Redis: &backendconfig.RedisConfig{
-				KeyPrefix:      "test",
-				Client:         client,
-				Backoff:        backoffConfig,
-				ChunkSizeInGet: 1000,
+				KeyPrefix:         "test",
+				Client:            client,
+				Backoff:           backoffConfig,
+				ChunkSizeInGet:    1000,
+				ChunkSizeInDelete: 1000,
 			},
 		})
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/backend/redis/redis_test.go
+++ b/pkg/backend/redis/redis_test.go
@@ -280,22 +280,16 @@ var _ = Describe("Backend", func() {
 			})
 			When("the large queue exists", func() {
 				It("can delete the queue", func() {
-					queue := testutil.MustCreateQueue(backend, SampleQueueSpec)
+					testutil.MustCreateQueue(backend, SampleQueueSpec)
 					// numOfTasks % chunkSize != 0 && numOfTasks > chunkSize
-					numOfTasks := 12345
+					numOfTasks := 1000 // numOfTasks < ChunkSizeInDelete
 					for i := 0; i < numOfTasks; i++ {
 						_, err := backend.AddTask(context.Background(), QueueName, SampleTaskSpec)
 						Expect(err).NotTo(HaveOccurred())
 					}
 
-					Expect(backend.DeleteQueue(context.Background(), SampleQueueSpec.Name)).NotTo(HaveOccurred())
-
-					queuesHash, err := client.HGetAll(backend.allQueuesKey()).Result()
-					Expect(err).NotTo(HaveOccurred())
-					Expect(len(queuesHash)).To(Equal(0))
-					keys, err := client.Keys(backend.queueKey(queue.UID.String()) + "*").Result()
-					Expect(err).NotTo(HaveOccurred())
-					Expect(len(keys)).To(Equal(0))
+					err := backend.DeleteQueue(context.Background(), SampleQueueSpec.Name)
+					Expect(err).To(Equal(iface.TaskQueueIsTooLarge))
 				})
 			})
 		})
@@ -1048,6 +1042,64 @@ var _ = Describe("Backend", func() {
 						// deadletter has 1 element
 						mustDeadletterLength(queue.UID.String(), 1)
 					})
+				})
+			})
+		})
+	})
+})
+
+var _ = Describe("BackendWihoutTransaction", func() {
+	var backend *Backend
+	BeforeEach(func() {
+		var err error
+		backoffConfig := backendconfig.DefaultBackoffConfig()
+		backoffConfig.MaxRetry = 0
+		ibackend, err := NewBackend(logger, backendconfig.Config{
+			BackendType: "redis",
+			Redis: &backendconfig.RedisConfig{
+				KeyPrefix:          "test",
+				Client:             client,
+				Backoff:            backoffConfig,
+				ChunkSizeInGet:     1000,
+				ChunkSizeInDelete:  1000,
+				WithoutTransaction: true,
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		backend, _ = ibackend.(*Backend)
+	})
+
+	AfterEach(func() {
+		keys, err := client.Keys("*").Result()
+		Expect(err).NotTo(HaveOccurred())
+		if len(keys) > 0 {
+			num, err := client.Del(keys...).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(num).To(Equal(int64(len(keys))))
+		}
+	})
+
+	Context("Queue Operation", func() {
+		Context("DeleteQueue", func() {
+			When("the large queue exists", func() {
+				It("can delete the queue", func() {
+					queue := testutil.MustCreateQueue(backend, SampleQueueSpec)
+					// numOfTasks % chunkSize != 0 && numOfTasks > chunkSize
+					// numOfTaksk <= chunSize
+					numOfTasks := 1000
+					for i := 0; i < numOfTasks; i++ {
+						_, err := backend.AddTask(context.Background(), QueueName, SampleTaskSpec)
+						Expect(err).NotTo(HaveOccurred())
+					}
+
+					Expect(backend.DeleteQueue(context.Background(), SampleQueueSpec.Name)).NotTo(HaveOccurred())
+
+					queuesHash, err := client.HGetAll(backend.allQueuesKey()).Result()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(len(queuesHash)).To(Equal(0))
+					keys, err := client.Keys(backend.queueKey(queue.UID.String()) + "*").Result()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(len(keys)).To(Equal(0))
 				})
 			})
 		})

--- a/pkg/backend/redis/task.go
+++ b/pkg/backend/redis/task.go
@@ -38,11 +38,11 @@ import (
 )
 
 const (
-	KB                     = 1 << 10
-	PayloadMaxSizeInKB     = 1
-	MessageMaxSizeInKB     = 1
-	HistoryLengthMax       = 10
-	MaxNameLength          = 1024
+	KB                 = 1 << 10
+	PayloadMaxSizeInKB = 1
+	MessageMaxSizeInKB = 1
+	HistoryLengthMax   = 10
+	MaxNameLength      = 1024
 )
 
 func (b *Backend) ensureQueueAndWorkerExists(queueUID, workerUID uuid.UUID) (*taskqueue.TaskQueue, *worker.Worker, error) {

--- a/pkg/backend/redis/worker.go
+++ b/pkg/backend/redis/worker.go
@@ -483,7 +483,7 @@ func (b *Backend) ensureWorkerExistsByUID(rds redis.Cmdable, queue *taskqueue.Ta
 }
 
 func (b *Backend) allWorkersKeysForDeleteQueue(rds redis.Cmdable, queueUID string) ([]string, error) {
-	keysToDelete := []string{b.workersKey(queueUID)}
+	keysToDelete := []string{}
 	workerUIDs, err := rds.SMembers(b.workersKey(queueUID)).Result()
 	if err == redis.Nil {
 		return []string{}, nil
@@ -497,5 +497,8 @@ func (b *Backend) allWorkersKeysForDeleteQueue(rds redis.Cmdable, queueUID strin
 			b.workerPendingTaskQueueKey(queueUID, workerUID),
 			b.workerTasksKey(queueUID, workerUID))
 	}
+
+	// If you are not using transactions, you need to delete the wokers key at the end.
+	keysToDelete = append(keysToDelete, b.workersKey(queueUID))
 	return keysToDelete, nil
 }

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -74,9 +74,10 @@ var _ = Describe("Worker", func() {
 		bcknd, err = backendfactory.NewBackend(logger, backendconfig.Config{
 			BackendType: "redis",
 			Redis: &backendconfig.RedisConfig{
-				Client:         client,
-				Backoff:        backendConfig,
-				ChunkSizeInGet: 1000,
+				Client:            client,
+				Backoff:           backendConfig,
+				ChunkSizeInGet:    1000,
+				ChunkSizeInDelete: 1000,
 			},
 		})
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Original PR #44 

We want to reduce redis load by delete-queue command when the queue has a large number of tasks.
*a large number is about 10^6

I implemented following improvements:

- add `--without-transaction` option to large queue delete
  - if the user doesn't set this option, keep old feature.
  - if the queue have many tasks and without this option, raise error.
- use SScan instead of SMembers command to fetch task UIDs
  - https://github.com/pfnet-research/pftaskqueue/commit/21b33e1ddf7fa3882d14a6340a84613726b733cd
- use UnLink instead of Del command and bulk deleting keys by chunk size
  - https://redis.io/commands/UNLINK
  - https://github.com/pfnet-research/pftaskqueue/commit/2b99cf7d427f0a8feab8066b7d93c286163f5378

- WIP points
  - Two pieces of code that are doing almost the same thing.
    - with / without transaction
  - Testing the corner case
    - i.e. abort and resume deleting
  - Performance test
    - I checked this PR work well for over 1234500 tasks
    - But it's take 20 minutes so it's not good for unite test.

fixes https://github.com/pfnet-research/pftaskqueue/issues/28